### PR TITLE
feat: add League Group Manager view types and query

### DIFF
--- a/llm.md
+++ b/llm.md
@@ -17,12 +17,16 @@ import {
   Season,
   League,
   LeagueGroup,
+  LeagueGroupView,
+  TeamDetail,
+  LeagueGroupStatistics,
   Club,
   Team,
   Person,
   Gym,
   Game,
   MatchDay,
+  PreferredMatchdayDate,
   SaveAssociationInput,
   SaveClubInput,
   SaveTeamInput,
@@ -706,6 +710,71 @@ function parseValidationErrors(message: string): Record<string, string[]> {
   }
   
   return errors;
+}
+```
+
+### League Group Manager View
+
+```typescript
+// League Group View types for comprehensive group management
+interface LeagueGroupView {
+  __typename?: 'LeagueGroupView';
+  group: LeagueGroup;
+  teams: TeamDetail[];
+  clubs: Club[];
+  gyms: Gym[];
+  statistics: LeagueGroupStatistics;
+}
+
+interface TeamDetail {
+  __typename?: 'TeamDetail';
+  id: Scalars['ID'];
+  club: Club;
+  name: Scalars['String'];
+  players: Person[];
+  withoutCompetition?: Maybe<Scalars['Boolean']>;
+  secondRightToPlay?: Maybe<Scalars['Boolean']>;
+  sgClub?: Maybe<Club>;
+  exemptionRequest?: Maybe<Scalars['String']>;
+  preferredDates?: Maybe<PreferredMatchdayDate[]>;
+}
+
+interface LeagueGroupStatistics {
+  __typename?: 'LeagueGroupStatistics';
+  totalTeams: Scalars['Int'];
+  totalPlayers: Scalars['Int'];
+  totalClubs: Scalars['Int'];
+  totalGyms: Scalars['Int'];
+}
+
+// Query for league group manager
+const getLeagueGroupViewArgs = {
+  groupId: 'group-123'
+};
+
+// Usage example
+async function exportLeagueGroupData(groupId: string): Promise<void> {
+  const groupView = await apiClient.query({
+    getLeagueGroupView: {
+      groupId
+    }
+  });
+
+  // Export teams with all players
+  const teamsExport = groupView.teams.map(team => ({
+    name: team.name,
+    club: team.club.name,
+    players: team.players.map(p => `${p.firstName} ${p.lastName}`),
+    withoutCompetition: team.withoutCompetition,
+    preferredDates: team.preferredDates
+  }));
+
+  // Export statistics
+  const stats = groupView.statistics;
+  console.log(`Total Teams: ${stats.totalTeams}`);
+  console.log(`Total Players: ${stats.totalPlayers}`);
+  console.log(`Total Clubs: ${stats.totalClubs}`);
+  console.log(`Total Gyms: ${stats.totalGyms}`);
 }
 ```
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -178,6 +178,34 @@ type PersonPermission @aws_cognito_user_pools {
   permission: String!
 }
 
+# League Group Manager View Types
+type LeagueGroupView @aws_cognito_user_pools {
+  group: LeagueGroup!
+  teams: [TeamDetail]!
+  clubs: [Club]!
+  gyms: [Gym]!
+  statistics: LeagueGroupStatistics
+}
+
+type TeamDetail @aws_cognito_user_pools {
+  id: ID!
+  club: Club!
+  name: String!
+  players: [Person]!
+  withoutCompetition: Boolean
+  secondRightToPlay: Boolean
+  sgClub: Club
+  exemptionRequest: String
+  preferredDates: [PreferredMatchdayDate]
+}
+
+type LeagueGroupStatistics @aws_cognito_user_pools {
+  totalTeams: Int!
+  totalPlayers: Int!
+  totalClubs: Int!
+  totalGyms: Int!
+}
+
 # Connection types for pagination
 
 type PersonConnection @aws_cognito_user_pools {
@@ -504,6 +532,9 @@ type Query {
   getAvailableDatesForSeason(seasonId: ID!, leagueId: ID): [PreferredMatchdayDate] @aws_cognito_user_pools
   
   getPersonPermissions(personId: ID!): [PersonPermission] @aws_cognito_user_pools(cognito_groups: ["admin"])
+
+  # League Group Manager comprehensive view - returns all relevant information for managing a league group
+  getLeagueGroupView(groupId: ID!): LeagueGroupView @aws_cognito_user_pools
 }
 
 # Mutations

--- a/src/generated/graphql.model.generated.ts
+++ b/src/generated/graphql.model.generated.ts
@@ -146,6 +146,23 @@ export type LeagueGroup = {
   shortName: Scalars['String']['output'];
 };
 
+export type LeagueGroupStatistics = {
+  __typename?: 'LeagueGroupStatistics';
+  totalClubs: Scalars['Int']['output'];
+  totalGyms: Scalars['Int']['output'];
+  totalPlayers: Scalars['Int']['output'];
+  totalTeams: Scalars['Int']['output'];
+};
+
+export type LeagueGroupView = {
+  __typename?: 'LeagueGroupView';
+  clubs: Array<Maybe<Club>>;
+  group: LeagueGroup;
+  gyms: Array<Maybe<Gym>>;
+  statistics?: Maybe<LeagueGroupStatistics>;
+  teams: Array<Maybe<TeamDetail>>;
+};
+
 export type MatchDay = {
   __typename?: 'MatchDay';
   commissioners?: Maybe<RefereeInfo>;
@@ -587,6 +604,7 @@ export type Query = {
   getGymById?: Maybe<Gym>;
   getLeagueById?: Maybe<League>;
   getLeagueGroupById?: Maybe<LeagueGroup>;
+  getLeagueGroupView?: Maybe<LeagueGroupView>;
   getListOfAssociations?: Maybe<Array<Maybe<Association>>>;
   getListOfClubs?: Maybe<ClubConnection>;
   getListOfClubsByAssociation?: Maybe<Array<Maybe<Club>>>;
@@ -684,6 +702,11 @@ export type QueryGetLeagueByIdArgs = {
 
 export type QueryGetLeagueGroupByIdArgs = {
   id: Scalars['ID']['input'];
+};
+
+
+export type QueryGetLeagueGroupViewArgs = {
+  groupId: Scalars['ID']['input'];
 };
 
 
@@ -954,6 +977,19 @@ export type Team = {
   leagueGroup?: Maybe<LeagueGroup>;
   name: Scalars['String']['output'];
   players: Array<Maybe<Person>>;
+  secondRightToPlay?: Maybe<Scalars['Boolean']['output']>;
+  sgClub?: Maybe<Club>;
+  withoutCompetition?: Maybe<Scalars['Boolean']['output']>;
+};
+
+export type TeamDetail = {
+  __typename?: 'TeamDetail';
+  club: Club;
+  exemptionRequest?: Maybe<Scalars['String']['output']>;
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  players: Array<Maybe<Person>>;
+  preferredDates?: Maybe<Array<Maybe<PreferredMatchdayDate>>>;
   secondRightToPlay?: Maybe<Scalars['Boolean']['output']>;
   sgClub?: Maybe<Club>;
   withoutCompetition?: Maybe<Scalars['Boolean']['output']>;


### PR DESCRIPTION

- Introduced new GraphQL types: `LeagueGroupView`, `TeamDetail`, and `LeagueGroupStatistics` for comprehensive management of league groups.
- Updated the GraphQL schema to include the `getLeagueGroupView` query, allowing retrieval of detailed information about league groups.
- Enhanced TypeScript definitions to reflect the new types and their relationships, facilitating better type safety and clarity in the codebase.

This change improves the API's capability to manage league groups effectively, providing essential data for teams, clubs, and statistics.